### PR TITLE
Set up action_groups in meta/runtime.yml

### DIFF
--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -25,5 +25,5 @@ sections:
   - Bugfixes
 - - known_issues
   - Known Issues
-title: CHANGE THIS IN changelogs/config.yaml!
+title: community.google
 trivial_section_name: trivial

--- a/changelogs/fragments/action_groups.yml
+++ b/changelogs/fragments/action_groups.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Added missing 'gcp' action_groups for community.google modules, allowing Ansible's module_defaults feature to be used

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -22,6 +22,7 @@ action_groups:
     - gcp_target_proxy
     - gcp_url_map
     - gcpubsub
+    - gcpubsub_facts
     - gcpubsub_info
     - gcspanner
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,30 @@
 ---
 requires_ansible: '>=2.9.10'
+action_groups:
+  gcp:
+    - gc_storage
+    - gcdns_record
+    - gcdns_zone
+    - gce
+    - gce_eip
+    - gce_img
+    - gce_instance_template
+    - gce_labels
+    - gce_lb
+    - gce_mig
+    - gce_net
+    - gce_pd
+    - gce_snapshot
+    - gce_tag
+    - gcp_backend_service
+    - gcp_forwarding_rule
+    - gcp_healthcheck
+    - gcp_target_proxy
+    - gcp_url_map
+    - gcpubsub
+    - gcpubsub_info
+    - gcspanner
+
 plugin_routing:
   modules:
     gcdns_record:


### PR DESCRIPTION
These allow for module_defaults to be used with the gcp group:
https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html#module-defaults-groups

Note that in order for this to work, we need to add community.google to ansible/ansible like https://github.com/ansible/ansible/pull/72496